### PR TITLE
[Design] 반응형 디테일 수정 

### DIFF
--- a/src/@components/about/benefit/BenefitDesktop/BenefitDesktop.jsx
+++ b/src/@components/about/benefit/BenefitDesktop/BenefitDesktop.jsx
@@ -8,6 +8,7 @@ export default function BenefitDesktop() {
   return (
     <S.BenefitWrapper>
       <S.HeaderTitleText>구름톤 유니브에서 마음껏 누려요!</S.HeaderTitleText>
+      <S.HeaderTitleTextSmall>구름톤 유니브에서 마음껏 누려요!</S.HeaderTitleTextSmall>
       <HorizontalScroll />
     </S.BenefitWrapper>
   );

--- a/src/@components/about/benefit/BenefitDesktop/style.jsx
+++ b/src/@components/about/benefit/BenefitDesktop/style.jsx
@@ -26,19 +26,28 @@ export const BenefitWrapper = styled.div`
 `;
 
 export const HeaderTitleText = styled.h2`
-  /* container-md */
-  @media screen and (min-width: 768px) {
-    width: 43rem;
-  }
-
-  /* container-xl */
-  @media screen and (min-width: 1200px) {
-    width: 71.25rem;
-  }
+  width: 71.25rem;
 
   text-align: start;
   position: absolute;
   top: 18%;
+
+  display: none;
+  @media screen and (min-width: 1200px) {
+    display: block;
+  }
+`;
+
+export const HeaderTitleTextSmall = styled.h3`
+  width: 43rem;
+
+  text-align: start;
+  position: absolute;
+  top: 18%;
+
+  @media screen and (min-width: 1200px) {
+    display: none;
+  }
 `;
 
 export const BenefitItemWrapper = styled.div`

--- a/src/@components/about/findingUniv/FindingUniv.jsx
+++ b/src/@components/about/findingUniv/FindingUniv.jsx
@@ -75,6 +75,7 @@ function FindingUniv() {
         </S.HeaderTitleWrapper>
         <S.HeaderUnivContainer>
           <S.HeaderUnivTitleText>현재 함께하는 유니브 10개</S.HeaderUnivTitleText>
+          <S.HeaderUnivTitleTextSmall>현재 함께하는 유니브 10개</S.HeaderUnivTitleTextSmall>
           <S.HeaderUnivListContainer>
             <AutoScrollingImages />
           </S.HeaderUnivListContainer>

--- a/src/@components/about/findingUniv/FindingUniv.jsx
+++ b/src/@components/about/findingUniv/FindingUniv.jsx
@@ -67,6 +67,7 @@ function FindingUniv() {
       <S.HeaderContainer>
         <S.HeaderTitleWrapper>
           <S.HeaderTitleText>새로운 유니브를 찾고 있어요!</S.HeaderTitleText>
+          <S.HeaderTitleTextSmall>새로운 유니브를 찾고 있어요!</S.HeaderTitleTextSmall>
 
           <S.GoormBtn color="primary" size="xl" tag="button" onClick={() => navigate('/recruit')}>
             자세히 보기

--- a/src/@components/about/findingUniv/style.jsx
+++ b/src/@components/about/findingUniv/style.jsx
@@ -44,6 +44,20 @@ export const RowPosters = styled.div`
 export const HeaderTitleText = styled.h2`
   text-align: center;
   margin-bottom: 1.5rem;
+
+  display: none;
+  @media screen and (min-width: 1200px) {
+    display: block;
+  }
+`;
+
+export const HeaderTitleTextSmall = styled.h3`
+  text-align: center;
+  margin-bottom: 1.5rem;
+
+  @media screen and (min-width: 1200px) {
+    display: none;
+  }
 `;
 
 export const HeaderUnivContainer = styled.div`

--- a/src/@components/about/findingUniv/style.jsx
+++ b/src/@components/about/findingUniv/style.jsx
@@ -69,8 +69,21 @@ export const HeaderUnivContainer = styled.div`
   width: 100%;
 `;
 
-export const HeaderUnivTitleText = styled.h5`
+export const HeaderUnivTitleText = styled.h3`
   margin-bottom: 1.5rem;
+  display: none;
+
+  @media screen and (min-width: 1200px) {
+    display: block;
+  }
+`;
+
+export const HeaderUnivTitleTextSmall = styled.h4`
+  margin-bottom: 1.5rem;
+
+  @media screen and (min-width: 1200px) {
+    display: none;
+  }
 `;
 
 export const HeaderUnivListContainer = styled.div`

--- a/src/@components/about/goal/style.jsx
+++ b/src/@components/about/goal/style.jsx
@@ -1,9 +1,14 @@
 import styled from 'styled-components';
 
 export const GoalWrapper = styled.div`
-  height: calc(100vh + 12.9375rem);
-  @supports (height: 100dvh) {
-    height: calc(100dvh + 12.9375rem);
+  @media screen and (min-width: 0px) {
+    height: 100%;
+  }
+  @media screen and (min-width: 576px) {
+    height: calc(100vh + 12.9375rem);
+    @supports (height: 100dvh) {
+      height: calc(100dvh + 12.9375rem);
+    }
   }
 
   position: relative;
@@ -119,8 +124,17 @@ export const ContentsWrapper = styled.div`
   /* container-xs, md */
   flex-direction: column;
 
+  @media screen and (min-width: 0px) {
+    margin-top: calc(12.9375rem + 7.5rem);
+  }
+
+  @media screen and (min-width: 576px) {
+    margin-top: 7.5rem;
+  }
+
   /* container-xl */
   @media screen and (min-width: 1200px) {
+    margin-top: 0;
     flex-direction: row;
   }
 `;

--- a/src/@components/about/intro/Intro.jsx
+++ b/src/@components/about/intro/Intro.jsx
@@ -31,12 +31,18 @@ export default function Intro({ scrollTarget }) {
       <S.MainCloudDownImg url={MainCloudDownImg} />
       <GridContainer>
         <S.HeaderTitleText>9oormthonUNIV 는</S.HeaderTitleText>
+        <S.HeaderTitleTextSmall>9oormthonUNIV 는</S.HeaderTitleTextSmall>
         <S.HeaderTextWrapper>
           <S.HeaderDescriptionText>
             봄과 가을을 기수로 하여
             <br />
             아이디어 실현의 장을 제공 해주는 IT 연합 동아리 입니다.
           </S.HeaderDescriptionText>
+          <S.HeaderDescriptionTextSmall>
+            봄과 가을을 기수로 하여
+            <br />
+            아이디어 실현의 장을 제공 해주는 IT 연합 동아리 입니다.
+          </S.HeaderDescriptionTextSmall>
         </S.HeaderTextWrapper>
         <S.ImgsWrapper>
           <S.Imgs>

--- a/src/@components/about/intro/style.jsx
+++ b/src/@components/about/intro/style.jsx
@@ -50,11 +50,41 @@ export const HeaderTitleText = styled.h5`
   color: var(--gray-600);
   margin-top: 2rem;
   margin-bottom: 1.5rem;
+  display: none;
+
+  @media screen and (min-width: 768px) {
+    display: block;
+  }
+`;
+
+export const HeaderTitleTextSmall = styled.h6`
+  text-align: center;
+  color: var(--gray-600);
+  margin-top: 2rem;
+  margin-bottom: 1.5rem;
+
+  @media screen and (min-width: 768px) {
+    display: none;
+  }
 `;
 
 export const HeaderDescriptionText = styled.h3`
   text-align: center;
   color: var(--gray-800);
+  display: none;
+
+  @media screen and (min-width: 768px) {
+    display: block;
+  }
+`;
+
+export const HeaderDescriptionTextSmall = styled.h4`
+  text-align: center;
+  color: var(--gray-800);
+
+  @media screen and (min-width: 768px) {
+    display: none;
+  }
 `;
 
 export const ImgsWrapper = styled.div`


### PR DESCRIPTION
## 🔥 Related Issues

- close #58

## ⛅️ 작업 내용

- [x] goal 섹션 height 조정
- [x] intro 섹션 작은 텍스트 추가
- [x] benefit 섹션 작은 텍스트 분기 수정
- [x] findingUniv 섹션 작은 텍스트 추가

## ✅ PR Point

<!-- 무슨 이유로 어떻게 코드를 변경했는지 -->
<!-- 어떤 위험이나 우려가 발견되었는지(팀원이 알아야 할 것) -->
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 -->

### 1. 모바일에서 goal 섹션 height가 너무 긴 문제 해결
#### 전
<img width="1128" alt="image" src="https://github.com/goormthon-Univ/goormthon_univ/assets/55528304/ceb90a62-6801-42b2-9175-bf0905b563c1"><br/>
#### 후
<img width="1128" alt="image" src="https://github.com/goormthon-Univ/goormthon_univ/assets/55528304/5e6f1e28-8a1e-4112-b752-54eb7e0ba6e1">

### 2. intro 섹션에서 container-s 이하로는 h3가 아닌 h4 사용

https://github.com/goormthon-Univ/goormthon_univ/assets/55528304/5dfed548-f5f7-4575-9f2c-42eed8fe1c96

### 3. benefit 섹션에서 container-md 이하로는 h2가 아닌 h3 사용

https://github.com/goormthon-Univ/goormthon_univ/assets/55528304/6163c58d-7bd2-4045-ab62-0b0450cc713e

### 4. findingUniv 섹션에서 container-md 이하로는 h2가 아닌 h3 사용 및 '현재 함께하는 유니브-' 텍스트 크기 수정


https://github.com/goormthon-Univ/goormthon_univ/assets/55528304/9341ccc6-6a17-48ee-bc03-84249ca39b8e

